### PR TITLE
Long live redis-hash

### DIFF
--- a/lib/redis/big_hash.rb
+++ b/lib/redis/big_hash.rb
@@ -2,7 +2,8 @@ require 'securerandom'
 
 class Redis
   class BigHash
-    include KeyHelpers
+    include ClientHelper
+    include KeyHelper
 
     attr_reader :namespace
 
@@ -87,23 +88,9 @@ class Redis
     end
     alias_method :destroy, :clear
 
-    protected
-
-      def redis
-        self.class.redis
-      end
-
     class << self
       def keys(redis_key)
         redis.hkeys redis_key
-      end
-
-      def redis
-        @@redis ||= NativeHash.redis
-      end
-
-      def redis=(client)
-        @@redis = client
       end
 
       def copy_hash(source_key, dest_key)

--- a/lib/redis/client_helper.rb
+++ b/lib/redis/client_helper.rb
@@ -1,0 +1,32 @@
+class Redis
+  class Client
+    def self.default
+      @@default_connection ||= ::Redis.new
+    end
+    def self.default=(connection)
+      @@default_connection = connection
+    end
+  end
+  module ClientHelper
+    def self.included(base)
+      base.send(:extend,  ClassMethods)
+      base.send(:include, InstanceMethods)
+    end
+    module InstanceMethods
+      def redis
+        @redis ||= self.class.redis
+      end
+      def redis=(connection)
+        @redis = connection
+      end
+    end
+    module ClassMethods
+      def redis
+        @@redis ||= ::Redis::Client.default
+      end
+      def redis=(connection)
+        @@redis = connection
+      end
+    end
+  end
+end

--- a/lib/redis/key_helper.rb
+++ b/lib/redis/key_helper.rb
@@ -1,5 +1,5 @@
 class Redis
-  module KeyHelpers
+  module KeyHelper
 
     def key
       @key ||= generate_key

--- a/lib/redis_hash.rb
+++ b/lib/redis_hash.rb
@@ -1,0 +1,21 @@
+require 'redis'
+require 'core_ext/hash' unless defined?(ActiveSupport)
+require 'redis/marshal'
+require 'redis/tracked_hash'
+require 'redis/client_helper'
+require 'redis/key_helper'
+require 'redis/big_hash'
+require 'redis/native_hash'
+
+if defined?(Rack::Session)
+  require "rack/session/abstract/id"
+  require 'rack/session/redis_hash'
+end
+
+if defined?(ActionDispatch::Session)
+  require 'action_dispatch/session/redis_hash'
+end
+
+if defined?(ActiveSupport)
+  require "active_support/cache/redis_store"
+end


### PR DESCRIPTION
Improved organization of Redis::NativeHash#save.
Improved connection management through Redis::ClientHelper.
Moved imports to enable 'redis-hash' require statements.

Figured using lib/redis-hash.rb as the required file would re-enable the use of `require 'redis-hash'` over `require 'redis/native_hash'`. I think the former is much cleaner. Also, requiring `redis/native_hash` when you're using `Redis::BigHash` is confusing. This change doesn't break code that requires `redis/native_hash` so both work... for now.

This also potentially means the gem name could revert to redis-hash...
